### PR TITLE
chore(integration_test): remove load-test-enabled and zap-enabled no-op flags (charmkeeper)

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,7 +11,6 @@ jobs:
       canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      load-test-enabled: false
       trivy-fs-enabled: true
       trivy-image-config: "trivy.yaml"
       self-hosted-runner: true


### PR DESCRIPTION
Remove `load-test-enabled` and `zap-enabled` from the integration test workflow.

These inputs have been removed from [operator-workflows](https://github.com/canonical/operator-workflows), causing CI failures in this repository. Removing them from the local workflow fixes the failing integration test jobs.

_This PR was created by [Charmkeeper](https://github.com/canonical/charmkeeper)._